### PR TITLE
add link to releases page from README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ To install the Eclipse plug-in, a user may either download the plug-in archive a
 === **import plug-in**
 To import, follow these steps:
 
-	. Download the archive from the SWAMP [releases](https://github.com/mirswamp/swamp-eclipse-plugin/releases) page and unzip it.
+	. Download the archive from the SWAMP https://github.com/mirswamp/swamp-eclipse-plugin/releases[releases] page and unzip it.
     . Open Eclipse Neon (or any version after it).
     . In the menu bar, select "Help > Install New Software".
     . In the "Install" dialog that comes up, click "Add...".

--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@ To install the Eclipse plug-in, a user may either download the plug-in archive a
 === **import plug-in**
 To import, follow these steps:
 
-	. Download the archive from the SWAMP releases page and unzip it.
+	. Download the archive from the SWAMP [releases](https://github.com/mirswamp/swamp-eclipse-plugin/releases) page and unzip it.
     . Open Eclipse Neon (or any version after it).
     . In the menu bar, select "Help > Install New Software".
     . In the "Install" dialog that comes up, click "Add...".


### PR DESCRIPTION
It wasn't immediately obvious to me where to find the "SWAMP releases page" especially because GitHub only shows the releases tab on the repo home page.